### PR TITLE
Fix TF Probability layers visualisation

### DIFF
--- a/visualkeras/layered.py
+++ b/visualkeras/layered.py
@@ -83,7 +83,10 @@ def layered_view(model, to_file: str = None, min_z: int = 20, min_xy: int = 20, 
         z = min_z
 
         if isinstance(layer.output_shape, tuple):
-            shape = layer.output_shape
+            if isinstance(layer.output_shape[0], tuple):
+                shape = layer.output_shape[0]
+            else:
+                shape = layer.output_shape
         elif isinstance(layer.output_shape, list) and len(
                 layer.output_shape) == 1:  # drop dimension for non seq. models
             shape = layer.output_shape[0]


### PR DESCRIPTION
Hi,

   this is the fix for issue #35. This change was tested with all independent layers, like IndependentBernoulli, IndependentLogistic, IndependentNormal and IndependentPoisson.

Here is the code for testing:
```python
# Create a stochastic encoder -- e.g., for use in a variational auto-encoder.
input_shape = [28, 28, 1]
encoded_shape = 2
encoder = tfk.Sequential([
  tfkl.InputLayer(input_shape=input_shape),
  tfkl.Conv2D(32, 3, activation='relu'),
  tfkl.Flatten(),
  tfkl.Dense(10, activation='relu'),
  tfkl.Dense(tfpl.IndependentNormal.params_size(encoded_shape)),
  tfp.layers.DenseFlipout(encoded_shape)
])

visualkeras.layered_view(encoder, legend=True)
```