### PR TITLE
Update PIL getsize method to getbbox 

### DIFF
--- a/visualkeras/layered.py
+++ b/visualkeras/layered.py
@@ -185,7 +185,7 @@ def layered_view(model, to_file: str = None, min_z: int = 20, min_xy: int = 20, 
         if font is None:
             font = ImageFont.load_default()
 
-        text_height = font.getsize("Ag")[1]
+        text_height = font.getbbox("Ag")[3]
         cube_size = text_height
 
         de = 0
@@ -196,8 +196,8 @@ def layered_view(model, to_file: str = None, min_z: int = 20, min_xy: int = 20, 
 
         for layer_type in layer_types:
             label = layer_type.__name__
-            text_size = font.getsize(label)
-            label_patch_size = (cube_size + de + spacing + text_size[0], cube_size + de)
+            text_size = font.getbbox(label)
+            label_patch_size = (cube_size + de + spacing + text_size[2], cube_size + de)
             # this only works if cube_size is bigger than text height
 
             img_box = Image.new('RGBA', label_patch_size, background_fill)


### PR DESCRIPTION
# Summary of Changes
This pull request addresses a compatibility issue with the latest version of PIL (Pillow), specifically version 10.2.0. In this version, the getsize method in the ImageFont module has been updated to getbbox ([documentation here](https://pillow.readthedocs.io/en/stable/reference/ImageFont.html)). This change impacts the `legend=True` functionality in visualkeras, leading to an error. This error was caused specifically by lines **188**, and **199**. 

Example:
```sh
Traceback (most recent call last):
  File ".../test.py", line 66, in <module>
    visualkeras.layered_view(model, scale_xy=10, legend=True)
  File ".../visualkeras/layered.py", line 188, in layered_view
    text_height = font.getsize("Ag")[1]
                  ^^^^^^^^^^^^
AttributeError: 'FreeTypeFont' object has no attribute 'getsize'
```

To resolve this issue, the pull request proposes the following changes:

Replace all instances of getsize with getbbox in the affected codebase.
Adjust the handling of the returned value from the getbbox method to ensure proper functionality and layout.

The following changes have been tested with different labels and scales, and works accurately. 

