### PR TITLE
Resolve issue #77

### DIFF
--- a/visualkeras/layered.py
+++ b/visualkeras/layered.py
@@ -403,7 +403,10 @@ def layered_view(model,
             if hasattr(font, 'getsize'):
                 text_size = font.getsize(label)
             else:
-                text_size = font.getbbox(label)
+                # Get last two values of the bounding box
+                # getbbox returns 4 dimensions in total, where the first two are always zero, 
+                # So we fetch the last two dimensions to match the behavior of getsize
+                text_size = font.getbbox(label)[2:]
             label_patch_size = (2 * cube_size + de + spacing + text_size[0], cube_size + de)
 
             # this only works if cube_size is bigger than text height


### PR DESCRIPTION
Fix Pillow incompatability with versions 10.0.0 and over. Before, text would not appear because `label_patch_size` would not take into account text width, due to changes in the `font.getbbox` method which offset the indicies for size.