### PR TITLE
Keras 3 compatibility, Model patch, shape helpers, graph fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Python bytecode
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Build artifacts / packaging
+build/
+dist/
+.eggs/
+*.egg-info/
+wheels/
+pip-wheel-metadata/
+*.egg
+MANIFEST
+
+# Tests / coverage
+.pytest_cache/
+htmlcov/
+.coverage
+.coverage.*
+nosetests.xml
+coverage.xml
+*.cover
+
+# Virtual environments
+.venv/
+venv/
+
+# Tool caches
+.mypy_cache/
+.pytype/
+.pyre/
+.ruff_cache/
+
+# Editors / IDE
+.vscode/
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ visualkeras.layered_view(model, sizing_mode='accurate')
 visualkeras.layered_view(model, sizing_mode='balanced')
 ```
 
-<img src="https://raw.githubusercontent.com/paulgavrikov/visualkeras/master/figures/sizing_balanced.pn" height="400"/>
+<img src="https://raw.githubusercontent.com/paulgavrikov/visualkeras/master/figures/sizing_balanced.png" height="400"/>
 
 **Capped mode**: Caps dimensions at specified limits while preserving ratios
 

--- a/visualkeras/layered.py
+++ b/visualkeras/layered.py
@@ -17,6 +17,9 @@ except:
         except:
             warnings.warn("Could not import the 'layers' module from Keras. text_callable will not work.")
 
+# Apply local compatibility patch (idempotent)
+ensure_singleton_sequence_unwrap_patched()
+
 def layered_view(model, 
                  to_file: str = None, 
                  min_z: int = 20, 
@@ -161,9 +164,10 @@ def layered_view(model,
                 # Fallback if even type() fails
                 layer_name = f'unknown_layer_{index}'
 
-        # Get the primary shape of the layer's output
-        shape = extract_primary_shape(layer.output_shape, layer_name)
-        
+        # Get the primary shape of the layer's output using a robust accessor (Keras 2/3 compatible)
+        raw_shape = get_layer_output_shape(layer)
+        shape = extract_primary_shape(raw_shape, layer_name)
+
         # Calculate dimensions with flexible sizing
         x, y, z = calculate_layer_dimensions(
             shape, scale_z, scale_xy,


### PR DESCRIPTION
### Summary
Modernizes visualkeras for Keras 3/TF >=2.16, removes deprecated APIs, adds robust shape helpers, applies a local patch for nested-model tuple issues, and refines graph_view layout. All tests pass.

### Key changes
- Introduced .gitignore to exclude common Python artifacts and build files.
- Updated `graph_view` and `layered_view` functions to improve compatibility with Keras 2 and 3.
- Added helper functions to retrieve layer input and output shapes robustly.
- Applied a patch to ensure single-item outputs are unwrapped correctly in Keras models.

### Testing
- Full suite passes (46 passed, ~20 warnings)
- Minor, intentional visual diffs in graph_view dimensions